### PR TITLE
consistency with proj4 updates

### DIFF
--- a/coordinateSystems.py
+++ b/coordinateSystems.py
@@ -108,6 +108,10 @@ class MapProjection(CoordinateSystem):
         return px, py, pz
         
     def fromECEF(self, x, y, z):
+        x = atleast_1d(x)
+        y = atleast_1d(y)
+        z = atleast_1d(z)
+        if (x.shape[0] == 0): return x, y, z # proj doesn't like empties
         projectedData = array(proj4.transform(CoordinateSystem.WGS84xyz, self.projection, x, y, z ))
         if len(projectedData.shape) == 1:
             px, py, pz = projectedData[0], projectedData[1], projectedData[2]


### PR DESCRIPTION
fromECEF function in MapProjection class of coordinateSystems.py module needs to be updated as per the proj4 requirements as discussed in lmatools issue #28 and #29 by @deeplycloudy.  

I just copied the same lines from coordinateSystem.py module in lmatools over here. 

This should fix the `pyproj.exceptions.ProjError: x,y,z, and time must be same size` error while running the `General calculations at grid points` block with `just_rms = False` in the LMAsimulation_full.ipynb file.